### PR TITLE
Remove import path for non-existent css file

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import './index.css';
 
 const App = () => <div className="App">Hello world!</div>;
 


### PR DESCRIPTION
## PR motivation:
This PR fixes the build failure caused by PR #3.
The build failure is caused by the App component trying to import a css file which is no longer being compiled because its scss file was deleted in PR #3.

## PR changes:
- Removes line importing `App/index.css`